### PR TITLE
Determining export directory correctly

### DIFF
--- a/Artwork/scripts/op_export.py
+++ b/Artwork/scripts/op_export.py
@@ -30,10 +30,9 @@ def ensure_collection(path):
 
 
 def output_path(path):
-    blender_dir = os.path.dirname(bpy.data.filepath)
-    artwork_dir = os.path.dirname(blender_dir)
-    stardeus_dir = os.path.dirname(artwork_dir)
-    graphics_dir = os.path.join(stardeus_dir, "Graphics/")
+    artwork_dir = os.path.dirname(bpy.data.filepath) # ./ModName/Artwork/ because blend file is located in Artwork by default
+    mod_dir = os.path.dirname(artwork_dir) # ./ModName/
+    graphics_dir = os.path.join(mod_dir, "Graphics/") # ./ModName/Graphics/
     if path.endswith("_"):
         path = path[:-1]
     return os.path.join(graphics_dir, path.replace('.', '/'))


### PR DESCRIPTION
Problem:
For now, blend file is located in ./Artwork so it results to an error in determining of output dir
Current functionality will result into falling to /Mods/ directory but not into actual ./ directory

Explanation:
1) blender_dir = .../Mods/modName/Artwork/
2) artwork_dir  = .../Mods/modName/
3) stardeus_dir = .../Mods/
4) graphics_dir = .../Mods/Graphics
5) Outputting into .../Mods/Graphics/...

Solution:
Changed output_path(path) to determine sprites output directory correctly. Now it basically one step shorter.

1) artwork_dir = .../Mods/modName/Artwork/
2) mod_dir = .../Mods/modName/
3) graphics_dir = .../Mods/modName/Graphics
4) Outputting into .../Mods/modName/Graphics/...